### PR TITLE
Fix links in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,8 @@ fn add(a: real, b: real) -> real {
 }
 ```
 
-you can see more examples [here](https://github.com/demetryf/smpl/tree/feature/add_typing/examples)
-and formal grammary [here](https://github.com/demetryf/smpl/tree/feature/add_typing/compiler/frontend/grammary.ebnff)
+you can see more examples [here](https://github.com/DemetryF/smpl/tree/main/examples)
+and formal grammary [here](https://github.com/DemetryF/smpl/blob/main/compiler/frontend/grammary.ebnf)
 
 # Typing
 


### PR DESCRIPTION
I discovered that the links to code examples and the EBNF grammar in your repository's readme.md are broken. After tremendous effort — and with the help of a private investigator — I found out that these links were apparently written under the influence of Garage Lime beer. They point to deleted branches, and the EBNF was spelled with an extra 'f'. Please accept my commit... and share the beer (I prefer SDEK).